### PR TITLE
chore: clarify usage instructions in README for button visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ Folders with nothing left? They vanish too. ✨
 ## Usage
 
 > ⚠️ **Heads up!**  
-> The buttons only appear if you open the Files Changed" page directly (like with [a refresh or direct link](https://github.com/HoangYell/github-pr-file-hider-button/pull/1/files)).  
-> If you click to the page from another GitHub tab (using the top navigation), the buttons might not show up.  
+> The buttons only appear if you open the "Files Changed" page directly (like with [a refresh or direct link](https://github.com/HoangYell/github-pr-file-hider-button/pull/1/files)).  
 > _It's not a bug, it's a feature. I swear!_ 🐞👻
 
 - Click **Hide** next to any file in the file tree to make it disappear (from the tree and the diff).

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ Folders with nothing left? They vanish too. ✨
 
 ## Usage
 
+> ⚠️ **Heads up!**  
+> The buttons only appear if you open the Files Changed" page directly (like with [a refresh or direct link](https://github.com/HoangYell/github-pr-file-hider-button/pull/1/files)).  
+> If you click to the page from another GitHub tab (using the top navigation), the buttons might not show up.  
+> _It's not a bug, it's a feature. I swear!_ 🐞👻
+
 - Click **Hide** next to any file in the file tree to make it disappear (from the tree and the diff).
 - Click **Show All Hidden Files** to restore everything.
 - Click **Share Hidden State** to copy a link that preserves your hidden files (great for code reviews).


### PR DESCRIPTION
This pull request updates the `README.md` file to provide additional usage instructions and clarify a specific behavior of the buttons in the file tree.

Documentation update:

* Added a note in the `README.md` under the "Usage" section to explain that the buttons for hiding files only appear when the "Files Changed" page is accessed directly (e.g., via refresh or direct link). It also humorously clarifies that this behavior is intentional.